### PR TITLE
[#14] [API] As a user, I can upload a CSV file of keywords

### DIFF
--- a/lib/crawler_web/controllers/api/auth_error_handler.ex
+++ b/lib/crawler_web/controllers/api/auth_error_handler.ex
@@ -1,4 +1,5 @@
 defmodule CrawlerWeb.Api.AuthErrorHandler do
+  import CrawlerWeb.Gettext
   import Plug.Conn
   import Phoenix.Controller
 
@@ -10,7 +11,8 @@ defmodule CrawlerWeb.Api.AuthErrorHandler do
     |> put_status(:unauthorized)
     |> render("error.json", %{
       code: "unauthorized",
-      detail: "Unauthorized"
+      detail: gettext("Unauthorized")
     })
+    |> halt()
   end
 end

--- a/lib/crawler_web/controllers/api/auth_error_handler.ex
+++ b/lib/crawler_web/controllers/api/auth_error_handler.ex
@@ -1,0 +1,16 @@
+defmodule CrawlerWeb.Api.AuthErrorHandler do
+  import Plug.Conn
+  import Phoenix.Controller
+
+  alias CrawlerWeb.Api.ErrorView
+
+  def auth_error(conn, {_type, _reason}, _opts) do
+    conn
+    |> put_view(ErrorView)
+    |> put_status(:unauthorized)
+    |> render("error.json", %{
+      code: "unauthorized",
+      detail: "Unauthorized"
+    })
+  end
+end

--- a/lib/crawler_web/controllers/api/auth_pipeline.ex
+++ b/lib/crawler_web/controllers/api/auth_pipeline.ex
@@ -1,0 +1,11 @@
+defmodule CrawlerWeb.Api.AuthPipeline do
+  use Guardian.Plug.Pipeline,
+    otp_app: :crawler,
+    module: Crawler.Account.Guardian,
+    error_handler: CrawlerWeb.Api.AuthErrorHandler
+
+  plug Guardian.Plug.VerifyHeader, scheme: "Bearer"
+  plug Guardian.Plug.EnsureAuthenticated
+  plug Guardian.Plug.LoadResource
+  plug CrawlerWeb.Plugs.SetCurrentUser
+end

--- a/lib/crawler_web/controllers/api/v1/keyword_controller.ex
+++ b/lib/crawler_web/controllers/api/v1/keyword_controller.ex
@@ -17,7 +17,7 @@ defmodule CrawlerWeb.Api.V1.KeywordController do
         parse_uploaded_file(conn, changeset.changes)
 
       false ->
-        show_error_flash_message_and_redirects_to_dasboard(
+        render_error_message(
           conn,
           gettext("The file doesn't look like CSV")
         )
@@ -54,13 +54,13 @@ defmodule CrawlerWeb.Api.V1.KeywordController do
   defp process_validation_error(conn, reason) do
     case reason do
       :file_empty ->
-        show_error_flash_message_and_redirects_to_dasboard(
+        render_error_message(
           conn,
           gettext("The file is empty")
         )
 
       :file_length_exceeded ->
-        show_error_flash_message_and_redirects_to_dasboard(
+        render_error_message(
           conn,
           gettext("The file is too big, allowed size is up to %{limit} keywords",
             limit: CSVParser.keywords_limit()
@@ -68,7 +68,7 @@ defmodule CrawlerWeb.Api.V1.KeywordController do
         )
 
       :keyword_length_exceeded ->
-        show_error_flash_message_and_redirects_to_dasboard(
+        render_error_message(
           conn,
           gettext("One or more keywords are invalid! Allowed keyword length is %{min}-%{max}",
             min: CSVParser.keyword_min_length(),
@@ -78,7 +78,7 @@ defmodule CrawlerWeb.Api.V1.KeywordController do
     end
   end
 
-  defp show_error_flash_message_and_redirects_to_dasboard(conn, message) do
+  defp render_error_message(conn, message) do
     conn
     |> put_view(ErrorView)
     |> put_status(:unprocessable_entity)

--- a/lib/crawler_web/controllers/api/v1/keyword_controller.ex
+++ b/lib/crawler_web/controllers/api/v1/keyword_controller.ex
@@ -1,0 +1,87 @@
+defmodule CrawlerWeb.Api.V1.KeywordController do
+  use CrawlerWeb, :controller
+
+  alias Crawler.Keyword.Helpers.CSVParser
+  alias Crawler.Keyword.Keywords
+  alias Crawler.Keyword.Schemas.KeywordCSVFile
+  alias CrawlerWeb.Api.ErrorView
+
+  def create(conn, %{"keyword_csv_file" => params}) do
+    changeset = %{
+      KeywordCSVFile.create_changeset(%KeywordCSVFile{}, %{file: params})
+      | action: :validate
+    }
+
+    case changeset.valid? do
+      true ->
+        parse_uploaded_file(conn, changeset.changes)
+
+      false ->
+        show_error_flash_message_and_redirects_to_dasboard(
+          conn,
+          gettext("The file doesn't look like CSV")
+        )
+    end
+  end
+
+  def create(conn, _params) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorView)
+    |> render("error.json", %{
+      code: :unprocessable_entity,
+      detail: gettext("Missing csv file, please add keyword_csv_file to the request's body")
+    })
+  end
+
+  defp parse_uploaded_file(conn, changes) do
+    case CSVParser.parse(changes.file.path) do
+      {:ok, keyword_list} ->
+        Keywords.create_keyword_list(keyword_list, conn.assigns.current_user.id)
+
+        render(conn, "show.json", %{
+          data: %{
+            id: :os.system_time(:millisecond),
+            message: gettext("Keywords were uploaded!")
+          }
+        })
+
+      {:error, reason} ->
+        process_validation_error(conn, reason)
+    end
+  end
+
+  defp process_validation_error(conn, reason) do
+    case reason do
+      :file_empty ->
+        show_error_flash_message_and_redirects_to_dasboard(
+          conn,
+          gettext("The file is empty")
+        )
+
+      :file_length_exceeded ->
+        show_error_flash_message_and_redirects_to_dasboard(
+          conn,
+          gettext("The file is too big, allowed size is up to %{limit} keywords",
+            limit: CSVParser.keywords_limit()
+          )
+        )
+
+      :keyword_length_exceeded ->
+        show_error_flash_message_and_redirects_to_dasboard(
+          conn,
+          gettext("One or more keywords are invalid! Allowed keyword length is %{min}-%{max}",
+            min: CSVParser.keyword_min_length(),
+            max: CSVParser.keyword_max_length()
+          )
+        )
+    end
+  end
+
+  defp show_error_flash_message_and_redirects_to_dasboard(conn, message) do
+    conn
+    |> put_view(ErrorView)
+    |> put_status(:unprocessable_entity)
+    |> render("error.json", %{code: :unprocessable_entity, detail: message})
+  end
+end

--- a/lib/crawler_web/plugs/set_current_user.ex
+++ b/lib/crawler_web/plugs/set_current_user.ex
@@ -1,0 +1,12 @@
+defmodule CrawlerWeb.Plugs.SetCurrentUser do
+  import Plug.Conn
+
+  alias Crawler.Account.Guardian.Plug
+
+  def init(_options), do: nil
+
+  def call(conn, _params) do
+    current_user = Plug.current_resource(conn)
+    assign(conn, :current_user, current_user)
+  end
+end

--- a/lib/crawler_web/router.ex
+++ b/lib/crawler_web/router.ex
@@ -64,7 +64,7 @@ defmodule CrawlerWeb.Router do
     pipe_through [:api, :api_auth]
 
     scope "/v1", Api.V1, as: :v1 do
-      post("/keyword/upload", KeywordController, :create)
+      post("/keyword", KeywordController, :create)
     end
   end
 end

--- a/lib/crawler_web/router.ex
+++ b/lib/crawler_web/router.ex
@@ -20,6 +20,10 @@ defmodule CrawlerWeb.Router do
     plug(:accepts, ["json"])
   end
 
+  pipeline :api_auth do
+    plug CrawlerWeb.Api.AuthPipeline
+  end
+
   # coveralls-ignore-stop
 
   forward(RouterHelper.health_path(), CrawlerWeb.HealthPlug)
@@ -53,6 +57,14 @@ defmodule CrawlerWeb.Router do
 
     scope "/v1", Api.V1, as: :v1 do
       post("/log_in", UserSessionController, :create)
+    end
+  end
+
+  scope "/api", CrawlerWeb, as: :api do
+    pipe_through [:api, :api_auth]
+
+    scope "/v1", Api.V1, as: :v1 do
+      post("/keyword/upload", KeywordController, :create)
     end
   end
 end

--- a/lib/crawler_web/views/api/v1/keyword_view.ex
+++ b/lib/crawler_web/views/api/v1/keyword_view.ex
@@ -1,0 +1,9 @@
+defmodule CrawlerWeb.Api.V1.KeywordView do
+  use JSONAPI.View, type: "keyword"
+
+  def fields do
+    [
+      :message
+    ]
+  end
+end

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -87,6 +87,7 @@ msgstr ""
 msgid "Keyword"
 msgstr ""
 
+#: lib/crawler_web/controllers/api/v1/keyword_controller.ex:73
 #: lib/crawler_web/controllers/keyword_controller.ex:63
 #, elixir-autogen, elixir-format
 msgid "One or more keywords are invalid! Allowed keyword length is %{min}-%{max}"
@@ -112,16 +113,19 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
+#: lib/crawler_web/controllers/api/v1/keyword_controller.ex:22
 #: lib/crawler_web/controllers/keyword_controller.ex:21
 #, elixir-autogen, elixir-format
 msgid "The file doesn't look like CSV"
 msgstr ""
 
+#: lib/crawler_web/controllers/api/v1/keyword_controller.ex:59
 #: lib/crawler_web/controllers/keyword_controller.ex:49
 #, elixir-autogen, elixir-format
 msgid "The file is empty"
 msgstr ""
 
+#: lib/crawler_web/controllers/api/v1/keyword_controller.ex:65
 #: lib/crawler_web/controllers/keyword_controller.ex:55
 #, elixir-autogen, elixir-format
 msgid "The file is too big, allowed size is up to %{limit} keywords"
@@ -140,4 +144,19 @@ msgstr ""
 #: lib/crawler_web/controllers/keyword_controller.ex:35
 #, elixir-autogen, elixir-format
 msgid "%{num_keyword} keywords were uploaded!"
+msgstr ""
+
+#: lib/crawler_web/controllers/api/v1/keyword_controller.ex:45
+#, elixir-autogen, elixir-format
+msgid "Keywords were uploaded!"
+msgstr ""
+
+#: lib/crawler_web/controllers/api/v1/keyword_controller.ex:33
+#, elixir-autogen, elixir-format
+msgid "Missing csv file, please add keyword_csv_file to the request's body"
+msgstr ""
+
+#: lib/crawler_web/controllers/api/auth_error_handler.ex:14
+#, elixir-autogen, elixir-format
+msgid "Unauthorized"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -88,6 +88,7 @@ msgstr ""
 msgid "Keyword"
 msgstr ""
 
+#: lib/crawler_web/controllers/api/v1/keyword_controller.ex:73
 #: lib/crawler_web/controllers/keyword_controller.ex:63
 #, elixir-autogen, elixir-format
 msgid "One or more keywords are invalid! Allowed keyword length is %{min}-%{max}"
@@ -113,16 +114,19 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
+#: lib/crawler_web/controllers/api/v1/keyword_controller.ex:22
 #: lib/crawler_web/controllers/keyword_controller.ex:21
 #, elixir-autogen, elixir-format
 msgid "The file doesn't look like CSV"
 msgstr ""
 
+#: lib/crawler_web/controllers/api/v1/keyword_controller.ex:59
 #: lib/crawler_web/controllers/keyword_controller.ex:49
 #, elixir-autogen, elixir-format
 msgid "The file is empty"
 msgstr ""
 
+#: lib/crawler_web/controllers/api/v1/keyword_controller.ex:65
 #: lib/crawler_web/controllers/keyword_controller.ex:55
 #, elixir-autogen, elixir-format
 msgid "The file is too big, allowed size is up to %{limit} keywords"
@@ -141,4 +145,19 @@ msgstr ""
 #: lib/crawler_web/controllers/keyword_controller.ex:35
 #, elixir-autogen, elixir-format
 msgid "%{num_keyword} keywords were uploaded!"
+msgstr ""
+
+#: lib/crawler_web/controllers/api/v1/keyword_controller.ex:45
+#, elixir-autogen, elixir-format
+msgid "Keywords were uploaded!"
+msgstr ""
+
+#: lib/crawler_web/controllers/api/v1/keyword_controller.ex:33
+#, elixir-autogen, elixir-format
+msgid "Missing csv file, please add keyword_csv_file to the request's body"
+msgstr ""
+
+#: lib/crawler_web/controllers/api/auth_error_handler.ex:14
+#, elixir-autogen, elixir-format
+msgid "Unauthorized"
 msgstr ""

--- a/test/crawler_web/controllers/api/auth_error_handler_test.exs
+++ b/test/crawler_web/controllers/api/auth_error_handler_test.exs
@@ -1,17 +1,20 @@
 defmodule CrawlerWeb.Api.AuthErrorHandlerTest do
   use CrawlerWeb.ConnCase, async: true
 
+  import CrawlerWeb.Gettext
+
   alias CrawlerWeb.Api.AuthErrorHandler
 
   describe "auth_error/2" do
     test "renders 401 error response", %{conn: conn} do
       conn = AuthErrorHandler.auth_error(conn, {:unauthorized, ""}, "")
+      detail = gettext("Unauthorized")
 
       assert %{
                "errors" => [
                  %{
                    "code" => "unauthorized",
-                   "detail" => "Unauthorized"
+                   "detail" => ^detail
                  }
                ]
              } = json_response(conn, :unauthorized)

--- a/test/crawler_web/controllers/api/auth_error_handler_test.exs
+++ b/test/crawler_web/controllers/api/auth_error_handler_test.exs
@@ -1,0 +1,22 @@
+defmodule CrawlerWeb.Api.AuthErrorHandlerTest do
+  use CrawlerWeb.ConnCase, async: true
+
+  alias CrawlerWeb.Api.AuthErrorHandler
+
+  describe "auth_error/2" do
+    test "renders 401 error response", %{conn: conn} do
+      conn = AuthErrorHandler.auth_error(conn, {:unauthorized, ""}, "")
+
+      assert %{
+               "errors" => [
+                 %{
+                   "code" => "unauthorized",
+                   "detail" => "Unauthorized"
+                 }
+               ]
+             } = json_response(conn, :unauthorized)
+
+      assert conn.halted
+    end
+  end
+end

--- a/test/crawler_web/controllers/api/v1/keyword_controller_test.exs
+++ b/test/crawler_web/controllers/api/v1/keyword_controller_test.exs
@@ -4,7 +4,7 @@ defmodule CrawlerWeb.Api.V1.KeywordControllerTest do
   alias Crawler.Keyword.Keywords
 
   describe "POST /keyword/upload" do
-    test "given valid keyword csv file, creates keyword successfully", %{conn: conn} do
+    test "given valid keyword csv file, creates keywords and returns 200", %{conn: conn} do
       user = insert(:user)
       uploaded_file = keyword_file_fixture("valid.csv")
       detail = gettext("Keywords were uploaded!")
@@ -38,7 +38,7 @@ defmodule CrawlerWeb.Api.V1.KeywordControllerTest do
       assert list == ["one", "two", "three"]
     end
 
-    test "given empty file, shows validation error", %{conn: conn} do
+    test "given empty file, returns 422 status", %{conn: conn} do
       user = insert(:user)
       uploaded_file = keyword_file_fixture("empty.csv")
       detail = gettext("The file is empty")

--- a/test/crawler_web/controllers/api/v1/keyword_controller_test.exs
+++ b/test/crawler_web/controllers/api/v1/keyword_controller_test.exs
@@ -1,0 +1,142 @@
+defmodule CrawlerWeb.Api.V1.KeywordControllerTest do
+  use CrawlerWeb.ConnCase, async: true
+
+  alias Crawler.Keyword.Keywords
+
+  describe "POST /keyword/upload" do
+    test "given valid keyword csv file, creates keyword successfully", %{conn: conn} do
+      user = insert(:user)
+      uploaded_file = keyword_file_fixture("valid.csv")
+
+      conn =
+        conn
+        |> auth_with_user(user)
+        |> post(Routes.api_v1_keyword_path(conn, :create), %{
+          keyword_csv_file: uploaded_file
+        })
+
+      assert %{
+               "data" => %{
+                 "attributes" => %{
+                   "message" => "Keywords were uploaded!"
+                 },
+                 "id" => _,
+                 "relationships" => %{},
+                 "type" => "keyword"
+               },
+               "included" => []
+             } = json_response(conn, 200)
+
+      keywords = Keywords.list_keywords(user.id)
+
+      list =
+        Enum.map(keywords, fn keyword ->
+          keyword.name
+        end)
+
+      assert list == ["one", "two", "three"]
+    end
+
+    test "given empty file, shows validation error", %{conn: conn} do
+      user = insert(:user)
+      uploaded_file = keyword_file_fixture("empty.csv")
+
+      conn =
+        conn
+        |> auth_with_user(user)
+        |> post(Routes.api_v1_keyword_path(conn, :create), %{
+          keyword_csv_file: uploaded_file
+        })
+
+      assert %{
+               "errors" => [
+                 %{
+                   "code" => "unprocessable_entity",
+                   "detail" => "The file is empty"
+                 }
+               ]
+             } = json_response(conn, 422)
+    end
+
+    test "given big file, shows validation error", %{conn: conn} do
+      user = insert(:user)
+      uploaded_file = keyword_file_fixture("big.csv")
+
+      conn =
+        conn
+        |> auth_with_user(user)
+        |> post(Routes.api_v1_keyword_path(conn, :create), %{
+          keyword_csv_file: uploaded_file
+        })
+
+      assert %{
+               "errors" => [
+                 %{
+                   "code" => "unprocessable_entity",
+                   "detail" => "The file is too big, allowed size is up to 1000 keywords"
+                 }
+               ]
+             } = json_response(conn, 422)
+    end
+
+    test "given non CSV file, shows validation error", %{conn: conn} do
+      user = insert(:user)
+      uploaded_file = keyword_file_fixture("non_csv.txt")
+
+      conn =
+        conn
+        |> auth_with_user(user)
+        |> post(Routes.api_v1_keyword_path(conn, :create), %{
+          keyword_csv_file: uploaded_file
+        })
+
+      assert %{
+               "errors" => [
+                 %{
+                   "code" => "unprocessable_entity",
+                   "detail" => "The file doesn't look like CSV"
+                 }
+               ]
+             } = json_response(conn, 422)
+    end
+
+    test "given file with invalid keywords, shows validation error", %{conn: conn} do
+      user = insert(:user)
+      uploaded_file = keyword_file_fixture("non_valid.csv")
+
+      conn =
+        conn
+        |> auth_with_user(user)
+        |> post(Routes.api_v1_keyword_path(conn, :create), %{
+          keyword_csv_file: uploaded_file
+        })
+
+      assert %{
+               "errors" => [
+                 %{
+                   "code" => "unprocessable_entity",
+                   "detail" => "One or more keywords are invalid! Allowed keyword length is 1-100"
+                 }
+               ]
+             } = json_response(conn, 422)
+    end
+
+    test "didn't give keyword csv file, shows validation error", %{conn: conn} do
+      user = insert(:user)
+
+      conn =
+        conn
+        |> auth_with_user(user)
+        |> post(Routes.api_v1_keyword_path(conn, :create))
+
+      assert %{
+               "errors" => [
+                 %{
+                   "code" => "unprocessable_entity",
+                   "detail" => "Missing csv file, please add keyword_csv_file to the request's body"
+                 }
+               ]
+             } = json_response(conn, 422)
+    end
+  end
+end

--- a/test/crawler_web/controllers/api/v1/keyword_controller_test.exs
+++ b/test/crawler_web/controllers/api/v1/keyword_controller_test.exs
@@ -7,6 +7,7 @@ defmodule CrawlerWeb.Api.V1.KeywordControllerTest do
     test "given valid keyword csv file, creates keyword successfully", %{conn: conn} do
       user = insert(:user)
       uploaded_file = keyword_file_fixture("valid.csv")
+      detail = gettext("Keywords were uploaded!")
 
       conn =
         conn
@@ -18,7 +19,7 @@ defmodule CrawlerWeb.Api.V1.KeywordControllerTest do
       assert %{
                "data" => %{
                  "attributes" => %{
-                   "message" => "Keywords were uploaded!"
+                   "message" => ^detail
                  },
                  "id" => _,
                  "relationships" => %{},
@@ -40,6 +41,7 @@ defmodule CrawlerWeb.Api.V1.KeywordControllerTest do
     test "given empty file, shows validation error", %{conn: conn} do
       user = insert(:user)
       uploaded_file = keyword_file_fixture("empty.csv")
+      detail = gettext("The file is empty")
 
       conn =
         conn
@@ -52,7 +54,7 @@ defmodule CrawlerWeb.Api.V1.KeywordControllerTest do
                "errors" => [
                  %{
                    "code" => "unprocessable_entity",
-                   "detail" => "The file is empty"
+                   "detail" => ^detail
                  }
                ]
              } = json_response(conn, 422)
@@ -61,6 +63,7 @@ defmodule CrawlerWeb.Api.V1.KeywordControllerTest do
     test "given big file, shows validation error", %{conn: conn} do
       user = insert(:user)
       uploaded_file = keyword_file_fixture("big.csv")
+      detail = gettext("The file is too big, allowed size is up to 1000 keywords")
 
       conn =
         conn
@@ -73,7 +76,7 @@ defmodule CrawlerWeb.Api.V1.KeywordControllerTest do
                "errors" => [
                  %{
                    "code" => "unprocessable_entity",
-                   "detail" => "The file is too big, allowed size is up to 1000 keywords"
+                   "detail" => ^detail
                  }
                ]
              } = json_response(conn, 422)
@@ -82,6 +85,7 @@ defmodule CrawlerWeb.Api.V1.KeywordControllerTest do
     test "given non CSV file, shows validation error", %{conn: conn} do
       user = insert(:user)
       uploaded_file = keyword_file_fixture("non_csv.txt")
+      detail = gettext("The file doesn't look like CSV")
 
       conn =
         conn
@@ -94,7 +98,7 @@ defmodule CrawlerWeb.Api.V1.KeywordControllerTest do
                "errors" => [
                  %{
                    "code" => "unprocessable_entity",
-                   "detail" => "The file doesn't look like CSV"
+                   "detail" => ^detail
                  }
                ]
              } = json_response(conn, 422)
@@ -103,6 +107,7 @@ defmodule CrawlerWeb.Api.V1.KeywordControllerTest do
     test "given file with invalid keywords, shows validation error", %{conn: conn} do
       user = insert(:user)
       uploaded_file = keyword_file_fixture("non_valid.csv")
+      detail = gettext("One or more keywords are invalid! Allowed keyword length is 1-100")
 
       conn =
         conn
@@ -115,7 +120,7 @@ defmodule CrawlerWeb.Api.V1.KeywordControllerTest do
                "errors" => [
                  %{
                    "code" => "unprocessable_entity",
-                   "detail" => "One or more keywords are invalid! Allowed keyword length is 1-100"
+                   "detail" => ^detail
                  }
                ]
              } = json_response(conn, 422)
@@ -123,6 +128,7 @@ defmodule CrawlerWeb.Api.V1.KeywordControllerTest do
 
     test "didn't give keyword csv file, shows validation error", %{conn: conn} do
       user = insert(:user)
+      detail = gettext("Missing csv file, please add keyword_csv_file to the request's body")
 
       conn =
         conn
@@ -133,7 +139,7 @@ defmodule CrawlerWeb.Api.V1.KeywordControllerTest do
                "errors" => [
                  %{
                    "code" => "unprocessable_entity",
-                   "detail" => "Missing csv file, please add keyword_csv_file to the request's body"
+                   "detail" => ^detail
                  }
                ]
              } = json_response(conn, 422)

--- a/test/crawler_web/plugs/set_current_user_test.exs
+++ b/test/crawler_web/plugs/set_current_user_test.exs
@@ -1,0 +1,24 @@
+defmodule CrawlerWeb.Plugs.SetCurrentUserTest do
+  use CrawlerWeb.ConnCase, async: true
+
+  import CrawlerWeb.Plugs.SetCurrentUser
+
+  describe "call/2" do
+    test "retrieves user data from session when it exists", %{conn: conn} do
+      created_user = insert(:user)
+
+      conn =
+        conn
+        |> Plug.Conn.put_private(:guardian_default_resource, created_user)
+        |> call(%{})
+
+      assert conn.assigns.current_user.id == created_user.id
+    end
+
+    test "retrieves user data from session when it does NOT exists", %{conn: conn} do
+      conn = call(conn, %{})
+
+      assert conn.assigns.current_user == nil
+    end
+  end
+end

--- a/test/crawler_web/plugs/set_current_user_test.exs
+++ b/test/crawler_web/plugs/set_current_user_test.exs
@@ -3,8 +3,11 @@ defmodule CrawlerWeb.Plugs.SetCurrentUserTest do
 
   import CrawlerWeb.Plugs.SetCurrentUser
 
+  alias CrawlerWeb.Plugs.SetCurrentUser
+
   describe "call/2" do
-    test "retrieves user data from session when it exists", %{conn: conn} do
+    test "given a user, retrieves user data from session", %{conn: conn} do
+      _ = SetCurrentUser.init({})
       created_user = insert(:user)
 
       conn =
@@ -15,7 +18,7 @@ defmodule CrawlerWeb.Plugs.SetCurrentUserTest do
       assert conn.assigns.current_user.id == created_user.id
     end
 
-    test "retrieves user data from session when it does NOT exists", %{conn: conn} do
+    test "given no user, doesn't retrieve user data from session", %{conn: conn} do
       conn = call(conn, %{})
 
       assert conn.assigns.current_user == nil

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -20,6 +20,7 @@ defmodule CrawlerWeb.ConnCase do
   import Crawler.Factory
 
   alias Crawler.Account.Accounts
+  alias Crawler.Account.Guardian
 
   using do
     quote do
@@ -71,4 +72,6 @@ defmodule CrawlerWeb.ConnCase do
     |> Phoenix.ConnTest.init_test_session(%{})
     |> Plug.Conn.put_session(:user_token, token)
   end
+
+  def auth_with_user(conn, user \\ insert(:user)), do: Guardian.Plug.sign_in(conn, user)
 end


### PR DESCRIPTION
Closes #14 

## What happened 👀

Upload keywords file
- Create a new endpoint: `api/v1/keyword` with method POST.
- Validate authorization before uploading.

## Insight 📝

- Create `AuthPipeline` to ensure the request is called from an authorized user.
- Create `AuthErrorHandler` to show `unauthorized` error.

## Proof Of Work 📹

<img width="1512" alt="Screenshot 2022-12-26 at 22 24 41" src="https://user-images.githubusercontent.com/17830319/209661827-622c0d60-1294-49eb-8e0c-b012156ab112.png">

