### PR TITLE
[#8] [API] As a user, I can register a new account with email and password

### DIFF
--- a/lib/crawler_web/controllers/api/v1/user_registration_controller.ex
+++ b/lib/crawler_web/controllers/api/v1/user_registration_controller.ex
@@ -10,13 +10,22 @@ defmodule CrawlerWeb.Api.V1.UserRegistrationController do
       {:ok, user} ->
         process_user_encode_and_sign(conn, user)
 
-      {:error, _changeset} ->
+      {:error, changeset} ->
+        # Enum.each(changeset.errors, fn error ->
+        #   case error do
+        #     {:email, reason} -> IO.inspect(reason)
+        #     {:password, reason} -> IO.inspect(reason)
+        #   end
+
+        #   # IO.inspect(error)
+        # end)
+
         conn
         |> put_view(ErrorView)
         |> put_status(:unprocessable_entity)
         |> render("error.json", %{
           code: :unprocessable_entity,
-          detail: gettext("%{email} has already been taken", email: email)
+          changeset: changeset
         })
     end
   end

--- a/lib/crawler_web/controllers/api/v1/user_registration_controller.ex
+++ b/lib/crawler_web/controllers/api/v1/user_registration_controller.ex
@@ -1,0 +1,51 @@
+defmodule CrawlerWeb.Api.V1.UserRegistrationController do
+  use CrawlerWeb, :controller
+
+  alias Crawler.Account.{Accounts, Guardian}
+  alias Crawler.Account.Schemas.User
+  alias CrawlerWeb.Api.ErrorView
+
+  def create(conn, %{"email" => email, "password" => password}) do
+    case Accounts.register_user(%{"email" => email, "password" => password}) do
+      {:ok, user} ->
+        process_user_encode_and_sign(conn, user)
+
+      {:error, _changeset} ->
+        conn
+        |> put_view(ErrorView)
+        |> put_status(:unprocessable_entity)
+        |> render("error.json", %{
+          code: :unprocessable_entity,
+          detail: gettext("%{email} has already been taken", email: email)
+        })
+    end
+  end
+
+  def create(conn, _params) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorView)
+    |> render("error.json", %{
+      code: :unprocessable_entity,
+      detail: gettext("Email or password is missing")
+    })
+  end
+
+  defp process_user_encode_and_sign(conn, %User{} = user) do
+    case Guardian.encode_and_sign(user, %{}) do
+      {:ok, token, _claims} ->
+        render(conn, "show.json", %{
+          data: %{id: :os.system_time(:millisecond), token: token, email: user.email}
+        })
+
+      {:error, _reason} ->
+        conn
+        |> put_view(ErrorView)
+        |> put_status(:internal_server_error)
+        |> render("error.json", %{
+          code: :internal_server_error,
+          detail: gettext("Internal server error")
+        })
+    end
+  end
+end

--- a/lib/crawler_web/controllers/api/v1/user_registration_controller.ex
+++ b/lib/crawler_web/controllers/api/v1/user_registration_controller.ex
@@ -11,20 +11,11 @@ defmodule CrawlerWeb.Api.V1.UserRegistrationController do
         process_user_encode_and_sign(conn, user)
 
       {:error, changeset} ->
-        # Enum.each(changeset.errors, fn error ->
-        #   case error do
-        #     {:email, reason} -> IO.inspect(reason)
-        #     {:password, reason} -> IO.inspect(reason)
-        #   end
-
-        #   # IO.inspect(error)
-        # end)
-
         conn
         |> put_view(ErrorView)
-        |> put_status(:unprocessable_entity)
+        |> put_status(:bad_request)
         |> render("error.json", %{
-          code: :unprocessable_entity,
+          code: :bad_request,
           changeset: changeset
         })
     end

--- a/lib/crawler_web/router.ex
+++ b/lib/crawler_web/router.ex
@@ -57,6 +57,7 @@ defmodule CrawlerWeb.Router do
 
     scope "/v1", Api.V1, as: :v1 do
       post("/log_in", UserSessionController, :create)
+      post("/register", UserRegistrationController, :create)
     end
   end
 

--- a/lib/crawler_web/views/api/error_view.ex
+++ b/lib/crawler_web/views/api/error_view.ex
@@ -1,8 +1,32 @@
 defmodule CrawlerWeb.Api.ErrorView do
   use CrawlerWeb, :view
 
+  alias Ecto.Changeset
+
+  def render("error.json", %{code: code, changeset: %Changeset{} = changeset}),
+    do: build_error_response(code, changeset)
+
   def render("error.json", %{code: code, detail: detail}),
     do: build_error_response(code: code, detail: detail)
+
+  defp to_sentence([message]), do: message
+
+  defp build_error_response(code, %Changeset{} = changeset) do
+    errors =
+      changeset
+      |> Changeset.traverse_errors(&translate_error/1)
+      |> Enum.map(&build_error_response(code, &1))
+
+    %{errors: errors}
+  end
+
+  defp build_error_response(code, {field, message}) do
+    %{
+      code: code,
+      source: %{parameter: field},
+      detail: "#{Phoenix.Naming.humanize(field)} #{to_sentence(message)}"
+    }
+  end
 
   defp build_error_response(code: code, detail: detail) do
     %{

--- a/lib/crawler_web/views/api/v1/user_registration_view.ex
+++ b/lib/crawler_web/views/api/v1/user_registration_view.ex
@@ -1,0 +1,10 @@
+defmodule CrawlerWeb.Api.V1.UserRegistrationView do
+  use JSONAPI.View, type: "user_registration"
+
+  def fields do
+    [
+      :token,
+      :email
+    ]
+  end
+end

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -72,13 +72,13 @@ msgstr ""
 msgid "Invalid email or password"
 msgstr ""
 
-#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:30
+#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:39
 #: lib/crawler_web/controllers/api/v1/user_session_controller.ex:38
 #, elixir-autogen, elixir-format
 msgid "Email or password is missing"
 msgstr ""
 
-#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:47
+#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:56
 #: lib/crawler_web/controllers/api/v1/user_session_controller.ex:27
 #, elixir-autogen, elixir-format
 msgid "Internal server error"
@@ -278,9 +278,4 @@ msgstr ""
 #: lib/crawler_web/templates/home/index.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "No keywords found, try with another keyword"
-msgstr ""
-
-#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:19
-#, elixir-autogen, elixir-format
-msgid "%{email} has already been taken"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -72,11 +72,13 @@ msgstr ""
 msgid "Invalid email or password"
 msgstr ""
 
+#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:30
 #: lib/crawler_web/controllers/api/v1/user_session_controller.ex:38
 #, elixir-autogen, elixir-format
 msgid "Email or password is missing"
 msgstr ""
 
+#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:47
 #: lib/crawler_web/controllers/api/v1/user_session_controller.ex:27
 #, elixir-autogen, elixir-format
 msgid "Internal server error"
@@ -276,4 +278,9 @@ msgstr ""
 #: lib/crawler_web/templates/home/index.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "No keywords found, try with another keyword"
+msgstr ""
+
+#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:19
+#, elixir-autogen, elixir-format
+msgid "%{email} has already been taken"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -72,13 +72,13 @@ msgstr ""
 msgid "Invalid email or password"
 msgstr ""
 
-#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:39
+#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:30
 #: lib/crawler_web/controllers/api/v1/user_session_controller.ex:38
 #, elixir-autogen, elixir-format
 msgid "Email or password is missing"
 msgstr ""
 
-#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:56
+#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:47
 #: lib/crawler_web/controllers/api/v1/user_session_controller.ex:27
 #, elixir-autogen, elixir-format
 msgid "Internal server error"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -73,13 +73,13 @@ msgstr ""
 msgid "Invalid email or password"
 msgstr ""
 
-#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:30
+#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:39
 #: lib/crawler_web/controllers/api/v1/user_session_controller.ex:38
 #, elixir-autogen, elixir-format
 msgid "Email or password is missing"
 msgstr ""
 
-#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:47
+#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:56
 #: lib/crawler_web/controllers/api/v1/user_session_controller.ex:27
 #, elixir-autogen, elixir-format
 msgid "Internal server error"
@@ -279,9 +279,4 @@ msgstr ""
 #: lib/crawler_web/templates/home/index.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "No keywords found, try with another keyword"
-msgstr ""
-
-#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:19
-#, elixir-autogen, elixir-format
-msgid "%{email} has already been taken"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -73,13 +73,13 @@ msgstr ""
 msgid "Invalid email or password"
 msgstr ""
 
-#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:39
+#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:30
 #: lib/crawler_web/controllers/api/v1/user_session_controller.ex:38
 #, elixir-autogen, elixir-format
 msgid "Email or password is missing"
 msgstr ""
 
-#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:56
+#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:47
 #: lib/crawler_web/controllers/api/v1/user_session_controller.ex:27
 #, elixir-autogen, elixir-format
 msgid "Internal server error"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -73,11 +73,13 @@ msgstr ""
 msgid "Invalid email or password"
 msgstr ""
 
+#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:30
 #: lib/crawler_web/controllers/api/v1/user_session_controller.ex:38
 #, elixir-autogen, elixir-format
 msgid "Email or password is missing"
 msgstr ""
 
+#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:47
 #: lib/crawler_web/controllers/api/v1/user_session_controller.ex:27
 #, elixir-autogen, elixir-format
 msgid "Internal server error"
@@ -277,4 +279,9 @@ msgstr ""
 #: lib/crawler_web/templates/home/index.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "No keywords found, try with another keyword"
+msgstr ""
+
+#: lib/crawler_web/controllers/api/v1/user_registration_controller.ex:19
+#, elixir-autogen, elixir-format
+msgid "%{email} has already been taken"
 msgstr ""

--- a/test/crawler_web/controllers/api/v1/user_registration_controller_test.exs
+++ b/test/crawler_web/controllers/api/v1/user_registration_controller_test.exs
@@ -1,0 +1,84 @@
+defmodule CrawlerWeb.Api.V1.UserRegistrationControllerTest do
+  use CrawlerWeb.ConnCase, async: true
+
+  alias Crawler.Account.Guardian
+
+  describe "POST create/2" do
+    test "given valid user credentials, returns access token", %{conn: conn} do
+      email = "new_email@gmail.com"
+
+      conn =
+        post(conn, Routes.api_v1_user_registration_path(conn, :create), %{
+          email: email,
+          password: "12345678"
+        })
+
+      assert %{
+               "data" => %{
+                 "attributes" => %{
+                   "email" => ^email,
+                   "token" => _
+                 },
+                 "id" => _,
+                 "relationships" => %{},
+                 "type" => "user_registration"
+               },
+               "included" => []
+             } = json_response(conn, 200)
+    end
+
+    test "given invalid user credentials, returns error response", %{conn: conn} do
+      conn = post(conn, Routes.api_v1_user_registration_path(conn, :create), %{})
+
+      assert json_response(conn, 422) == %{
+               "errors" => [
+                 %{
+                   "code" => "unprocessable_entity",
+                   "detail" => gettext("Email or password is missing")
+                 }
+               ]
+             }
+    end
+
+    test "given existing user credentials, returns error response", %{conn: conn} do
+      %{email: email, password: password} = insert(:user)
+
+      conn =
+        post(conn, Routes.api_v1_user_registration_path(conn, :create), %{
+          email: email,
+          password: password
+        })
+
+      assert json_response(conn, 422) == %{
+               "errors" => [
+                 %{
+                   "code" => "unprocessable_entity",
+                   "detail" => gettext("%{email} has already been taken", email: email)
+                 }
+               ]
+             }
+    end
+
+    test "given valid user credentials when encode_and_sign returns error, returns error response",
+         %{
+           conn: conn
+         } do
+      stub(Guardian, :encode_and_sign, fn _, _ -> {:error, "error"} end)
+
+      conn =
+        post(conn, Routes.api_v1_user_registration_path(conn, :create), %{
+          email: "email@gmail.com",
+          password: "12345678"
+        })
+
+      assert json_response(conn, 500) == %{
+               "errors" => [
+                 %{
+                   "code" => "internal_server_error",
+                   "detail" => gettext("Internal server error")
+                 }
+               ]
+             }
+    end
+  end
+end

--- a/test/crawler_web/controllers/api/v1/user_registration_controller_test.exs
+++ b/test/crawler_web/controllers/api/v1/user_registration_controller_test.exs
@@ -127,5 +127,55 @@ defmodule CrawlerWeb.Api.V1.UserRegistrationControllerTest do
                ]
              }
     end
+
+    test "given a valid user credentials with an authenticated user, returns access token",
+         %{
+           conn: conn
+         } do
+      user = insert(:user)
+      email = "new_email@gmail.com"
+
+      conn =
+        conn
+        |> auth_with_user(user)
+        |> post(Routes.api_v1_user_registration_path(conn, :create), %{
+          email: email,
+          password: "12345678"
+        })
+
+      assert %{
+               "data" => %{
+                 "attributes" => %{
+                   "email" => ^email,
+                   "token" => _
+                 },
+                 "id" => _,
+                 "relationships" => %{},
+                 "type" => "user_registration"
+               },
+               "included" => []
+             } = json_response(conn, 200)
+    end
+
+    test "given an invalid user credentials with an authenticated user, returns error response",
+         %{
+           conn: conn
+         } do
+      user = insert(:user)
+
+      conn =
+        conn
+        |> auth_with_user(user)
+        |> post(Routes.api_v1_user_registration_path(conn, :create), %{})
+
+      assert json_response(conn, 422) == %{
+               "errors" => [
+                 %{
+                   "code" => "unprocessable_entity",
+                   "detail" => gettext("Email or password is missing")
+                 }
+               ]
+             }
+    end
   end
 end

--- a/test/crawler_web/controllers/api/v1/user_registration_controller_test.exs
+++ b/test/crawler_web/controllers/api/v1/user_registration_controller_test.exs
@@ -49,10 +49,10 @@ defmodule CrawlerWeb.Api.V1.UserRegistrationControllerTest do
           password: password
         })
 
-      assert json_response(conn, 422) == %{
+      assert json_response(conn, 400) == %{
                "errors" => [
                  %{
-                   "code" => "unprocessable_entity",
+                   "code" => "bad_request",
                    "detail" => gettext("Email has already been taken"),
                    "source" => %{"parameter" => "email"}
                  }
@@ -69,10 +69,10 @@ defmodule CrawlerWeb.Api.V1.UserRegistrationControllerTest do
           password: "123456"
         })
 
-      assert json_response(conn, 422) == %{
+      assert json_response(conn, 400) == %{
                "errors" => [
                  %{
-                   "code" => "unprocessable_entity",
+                   "code" => "bad_request",
                    "detail" => gettext("Password should be at least 8 character(s)"),
                    "source" => %{"parameter" => "password"}
                  }
@@ -91,16 +91,16 @@ defmodule CrawlerWeb.Api.V1.UserRegistrationControllerTest do
           password: "123456"
         })
 
-      assert errors = json_response(conn, 422)
+      assert errors = json_response(conn, 400)
 
       assert %{
-               "code" => "unprocessable_entity",
+               "code" => "bad_request",
                "detail" => gettext("Password should be at least 8 character(s)"),
                "source" => %{"parameter" => "password"}
              } in errors["errors"] == true
 
       assert %{
-               "code" => "unprocessable_entity",
+               "code" => "bad_request",
                "detail" => gettext("Email has already been taken"),
                "source" => %{"parameter" => "email"}
              } in errors["errors"] == true

--- a/test/crawler_web/views/api/error_view_test.exs
+++ b/test/crawler_web/views/api/error_view_test.exs
@@ -3,7 +3,8 @@ defmodule CrawlerWeb.Api.ErrorViewTest do
 
   import Phoenix.View
 
-  # alias Crawler.Account.Accounts
+  alias Crawler.Account.Accounts
+  alias Crawler.Account.Schemas.User
   alias CrawlerWeb.Api.ErrorView
 
   describe "render/2" do
@@ -19,6 +20,45 @@ defmodule CrawlerWeb.Api.ErrorViewTest do
                  }
                ]
              }
+    end
+
+    test "given changeset error with multiple errors fields, renders error json" do
+      changeset = Accounts.change_user_registration(%User{}, %{email: "email", password: "123456"})
+      error = %{code: :unprocessable_entity, changeset: changeset}
+
+      assert render(ErrorView, "error.json", error) ==
+               %{
+                 errors: [
+                   %{
+                     code: :unprocessable_entity,
+                     detail: "Email must have the @ sign and no spaces",
+                     source: %{parameter: :email}
+                   },
+                   %{
+                     code: :unprocessable_entity,
+                     detail: "Password should be at least 8 character(s)",
+                     source: %{parameter: :password}
+                   }
+                 ]
+               }
+    end
+
+    test "given changeset error with a single error, renders error json" do
+      changeset =
+        Accounts.change_user_registration(%User{}, %{email: "email", password: "12345678"})
+
+      error = %{code: :unprocessable_entity, changeset: changeset}
+
+      assert render(ErrorView, "error.json", error) ==
+               %{
+                 errors: [
+                   %{
+                     code: :unprocessable_entity,
+                     detail: "Email must have the @ sign and no spaces",
+                     source: %{parameter: :email}
+                   }
+                 ]
+               }
     end
   end
 end


### PR DESCRIPTION
close #8

## What happened 👀

Create API for registering new account

## Insight 📝

- Create a new endpoint: `{POST /api/v1/register}`
- Add unit test

## Proof Of Work 📹

![Screenshot 2023-02-06 at 13 46 51](https://user-images.githubusercontent.com/17830319/216932978-79a7ebc5-fea0-4143-b348-b822b572906f.png)
